### PR TITLE
Features/pytorch 1.2 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir numpy scipy scikit-learn nltk emoji
 
-RUN pip install --no-cache-dir pandas cupy
+RUN pip install --no-cache-dir pandas cupy-cuda92
 
 RUN pip install --no-cache-dir boto boto3 fastText
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM floydhub/pytorch:1.1.0-gpu.cuda9cudnn7-py3.44
+FROM floydhub/pytorch:latest-gpu-py3
+
+RUN pip3 install torch==1.2.0+cu92 torchvision==0.4.0+cu92 -f https://download.pytorch.org/whl/torch_stable.html
 
 RUN pip install --upgrade pip
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ nltk packages:
 # 0.6
 
 Updated the base floydhub image to `1.1.0-gpu.cuda9cudnn7-py3.44` to use the latest pytorch version
+
+# 0.7
+
+Update the pytorch version to `1.2` using the floydhub image `pytorch:latest-gpu-py3`


### PR DESCRIPTION
This feature is to upgrade pytorch to 1.2.0 using cuda9.2.
The python version will be 3.5 instead of 3.4